### PR TITLE
feat:Ignore description content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=complexbear
 NAME=opencga
 BINARY=terraform-provider-${NAME}
-VERSION=0.4.1
+VERSION=0.4.2
 OS_ARCH=darwin_amd64
 
 default: help

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=complexbear
 NAME=opencga
 BINARY=terraform-provider-${NAME}
-VERSION=0.4.0
+VERSION=0.4.1
 OS_ARCH=darwin_amd64
 
 default: help

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=complexbear
 NAME=opencga
 BINARY=terraform-provider-${NAME}
-VERSION=0.4.2
+VERSION=0.4.3
 OS_ARCH=darwin_amd64
 
 default: help

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -36,6 +36,10 @@ resource "opencga_project" "new_project" {
 - `scientific_name` (String) Usually this is `Homo Sapiens`
 - `taxonomy_code` (Number) Usually this is `9606`
 
+### Optional
+
+- `checkDescription` (Boolean) If true the description content will be checked against the state
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/study.md
+++ b/docs/resources/study.md
@@ -33,6 +33,7 @@ resource "opencga_study" "a_cohort" {
 
 ### Optional
 
+- `checkDescription` (Boolean) If true the description content will be checked against the state
 - `project` (String) The `id` of the project this study is associated with.
 
 ### Read-Only

--- a/docs/resources/variableset.md
+++ b/docs/resources/variableset.md
@@ -34,6 +34,7 @@ resource "opencga_variableset" "new_var_set" {
 
 ### Optional
 
+- `checkDescription` (Boolean) If true the description content will be checked against the state
 - `study` (String) The study that this variable set belongs to
 
 ### Read-Only

--- a/opencga/resource_project.go
+++ b/opencga/resource_project.go
@@ -37,9 +37,10 @@ func resourceProject() *schema.Resource {
 				Description: "Project alias. Do not supply the `null@` prefix seen in created resources. This will be added by OpenCGA automatically",
 			},
 			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      descriptionDiffSuppressFunc,
+				DiffSuppressOnRefresh: true,
 			},
 			"scientific_name": &schema.Schema{
 				Type:        schema.TypeString,
@@ -155,4 +156,10 @@ func aliasStateFunc(v interface{}) string {
 	} else {
 		return "null@" + s
 	}
+}
+
+func descriptionDiffSuppressFunc(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	// Ignore description content
+	// This is also used in study and variableset resources
+	return true
 }

--- a/opencga/resource_project.go
+++ b/opencga/resource_project.go
@@ -60,6 +60,12 @@ func resourceProject() *schema.Resource {
 				ForceNew:    true,
 				Description: "Reference genome assembly name. i.e. GRCh38",
 			},
+			"checkDescription": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "If true the description content will be checked against the state",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -159,7 +165,11 @@ func aliasStateFunc(v interface{}) string {
 }
 
 func descriptionDiffSuppressFunc(k, oldValue, newValue string, d *schema.ResourceData) bool {
-	// Ignore description content
+	// Ignore description content if user wishes it
 	// This is also used in study and variableset resources
+	check, ok := d.GetOk("checkDescription")
+	if ok && check.(bool) {
+		return oldValue == newValue
+	}
 	return true
 }

--- a/opencga/resource_project.go
+++ b/opencga/resource_project.go
@@ -16,7 +16,7 @@ func resourceProject() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceProjectCreate,
 		ReadContext:   resourceProjectRead,
-		// 		UpdateContext: resourceProjectUpdate,
+		UpdateContext: resourceProjectUpdate,
 		DeleteContext: resourceProjectDelete,
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
@@ -60,11 +60,13 @@ func resourceProject() *schema.Resource {
 				ForceNew:    true,
 				Description: "Reference genome assembly name. i.e. GRCh38",
 			},
-			"checkDescription": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "If true the description content will be checked against the state",
+			"check_description": &schema.Schema{
+				Type:                  schema.TypeBool,
+				Optional:              true,
+				Default:               true,
+				DiffSuppressFunc:      checkDescDiffSuppressFunc,
+				DiffSuppressOnRefresh: true,
+				Description:           "If true the description content will be checked against the state",
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -167,9 +169,14 @@ func aliasStateFunc(v interface{}) string {
 func descriptionDiffSuppressFunc(k, oldValue, newValue string, d *schema.ResourceData) bool {
 	// Ignore description content if user wishes it
 	// This is also used in study and variableset resources
-	check, ok := d.GetOk("checkDescription")
+	check, ok := d.GetOk("check_description")
 	if ok && check.(bool) {
 		return oldValue == newValue
 	}
+	return true
+}
+
+func checkDescDiffSuppressFunc(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	// This isn't stored as part of the state in the opencga instance
 	return true
 }

--- a/opencga/resource_study.go
+++ b/opencga/resource_study.go
@@ -45,6 +45,12 @@ func resourceStudy() *schema.Resource {
 				DiffSuppressFunc:      descriptionDiffSuppressFunc,
 				DiffSuppressOnRefresh: true,
 			},
+			"checkDescription": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "If true the description content will be checked against the state",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -134,4 +140,3 @@ func resourceStudyDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	log.Printf("Pretending to delete but doing nothing....")
 	return diags
 }
-

--- a/opencga/resource_study.go
+++ b/opencga/resource_study.go
@@ -45,11 +45,13 @@ func resourceStudy() *schema.Resource {
 				DiffSuppressFunc:      descriptionDiffSuppressFunc,
 				DiffSuppressOnRefresh: true,
 			},
-			"checkDescription": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "If true the description content will be checked against the state",
+			"check_description": &schema.Schema{
+				Type:                  schema.TypeBool,
+				Optional:              true,
+				Default:               true,
+				DiffSuppressFunc:      checkDescDiffSuppressFunc,
+				DiffSuppressOnRefresh: true,
+				Description:           "If true the description content will be checked against the state",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/opencga/resource_study.go
+++ b/opencga/resource_study.go
@@ -40,9 +40,10 @@ func resourceStudy() *schema.Resource {
 				Description: "Study alias name",
 			},
 			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      descriptionDiffSuppressFunc,
+				DiffSuppressOnRefresh: true,
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -133,3 +134,4 @@ func resourceStudyDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	log.Printf("Pretending to delete but doing nothing....")
 	return diags
 }
+

--- a/opencga/resource_variableset.go
+++ b/opencga/resource_variableset.go
@@ -57,6 +57,12 @@ func resourceVariableSet() *schema.Resource {
 				DiffSuppressOnRefresh: true,
 				Description:           "Json content representing the variables in this variable set. Json definitions can be read directly from the GelReportModels repo.",
 			},
+			"checkDescription": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "If true the description content will be checked against the state",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/opencga/resource_variableset.go
+++ b/opencga/resource_variableset.go
@@ -57,11 +57,13 @@ func resourceVariableSet() *schema.Resource {
 				DiffSuppressOnRefresh: true,
 				Description:           "Json content representing the variables in this variable set. Json definitions can be read directly from the GelReportModels repo.",
 			},
-			"checkDescription": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "If true the description content will be checked against the state",
+			"check_description": &schema.Schema{
+				Type:                  schema.TypeBool,
+				Optional:              true,
+				Default:               true,
+				DiffSuppressFunc:      checkDescDiffSuppressFunc,
+				DiffSuppressOnRefresh: true,
+				Description:           "If true the description content will be checked against the state",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/opencga/resource_variableset.go
+++ b/opencga/resource_variableset.go
@@ -43,9 +43,11 @@ func resourceVariableSet() *schema.Resource {
 				Description: "True if there can only be 1 instance of this attached to a record item. False to allow for multiple instances.",
 			},
 			"description": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Description, can be left blank",
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      descriptionDiffSuppressFunc,
+				DiffSuppressOnRefresh: true,
+				Description:           "Description, can be left blank",
 			},
 			"variables": &schema.Schema{
 				Type:                  schema.TypeString,


### PR DESCRIPTION
Existing opencga instances very often have discrepancies between the resource descriptions in different environments. This ignores the description content.